### PR TITLE
Busco

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -79,6 +79,13 @@ process {
         ]
     }
 
+    withName: 'BUSCO_BUSCO' {
+        publishDir = [
+            path: { "${params.outdir}/busco" },
+            mode: params.publish_dir_mode
+        ]
+    }
+
     withName: 'CUSTOM_DUMPSOFTWAREVERSIONS' {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },
@@ -86,4 +93,5 @@ process {
             pattern: '*_versions.yml'
         ]
     }
+
 }

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ log.info """\
 
  Authors:
    - Chris Wyatt <c.wyatt@ucl.ac.uk>
-   - Simon Murray <simon.murray@ucl.ac.uk>
+   - Simon Murray
 
  -----------------------------------------
 
@@ -30,8 +30,8 @@ include { CAFE_GO } from './modules/local/cafe_go.nf'
 include { CAFE_PLOT } from './modules/local/cafe_plot.nf'
 
 include { validateParameters; paramsHelp; paramsSummaryLog } from 'plugin/nf-validation'
-include { CUSTOM_DUMPSOFTWAREVERSIONS } from './modules/nf-core/custom/dumpsoftwareversions/main'
-
+include { CUSTOM_DUMPSOFTWAREVERSIONS } from './modules/nf-core/custom/dumpsoftwareversions/main.nf'
+include { BUSCO_BUSCO } from './modules/nf-core/busco/busco/main.nf'
 
 workflow {
 
@@ -63,6 +63,13 @@ workflow {
 
    GFFREAD ( DOWNLOAD_NCBI.out.genome.mix(input_type.local) )
    ch_versions = ch_versions.mix(GFFREAD.out.versions.first())
+
+   BUSCO_BUSCO ( GFFREAD.out.proteins_busco , 
+                 params.busco_mode,
+                 params.busco_lineage,
+                 params.busco_lineages_path ?: [],
+                 params.busco_config ?: [], 
+               )
 
    merge_ch = GFFREAD.out.longest.collect()
    

--- a/main.nf
+++ b/main.nf
@@ -64,12 +64,15 @@ workflow {
    GFFREAD ( DOWNLOAD_NCBI.out.genome.mix(input_type.local) )
    ch_versions = ch_versions.mix(GFFREAD.out.versions.first())
 
-   BUSCO_BUSCO ( GFFREAD.out.proteins_busco , 
-                 params.busco_mode,
-                 params.busco_lineage,
-                 params.busco_lineages_path ?: [],
-                 params.busco_config ?: [], 
-               )
+   if (params.busco){
+      BUSCO_BUSCO (  GFFREAD.out.proteins_busco , 
+                     params.busco_mode,
+                     params.busco_lineage,
+                     params.busco_lineages_path ?: [],
+                     params.busco_config ?: [], 
+                  )
+   }
+   
 
    merge_ch = GFFREAD.out.longest.collect()
    

--- a/modules/local/gffread.nf
+++ b/modules/local/gffread.nf
@@ -8,6 +8,7 @@ process GFFREAD {
 
     output:
     path( "${sample_id}.prot.fa" ), emit: proteins
+    tuple val(sample_id), path("${sample_id}.prot.fa.largestIsoform.fa" ), emit: proteins_busco
     path( "${sample_id}.prot.fa.largestIsoform.fa" ), emit: longest
     path( "${sample_id}.splicedcds.fa" )
     path( "${sample_id}.splicedexons.fa" )

--- a/modules/nf-core/busco/busco/main.nf
+++ b/modules/nf-core/busco/busco/main.nf
@@ -1,0 +1,106 @@
+process BUSCO_BUSCO {
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/busco:5.7.1--pyhdfd78af_0':
+        'biocontainers/busco:5.7.1--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(fasta, stageAs:'tmp_input/*')
+    val mode                              // Required:    One of genome, proteins, or transcriptome
+    val lineage                           // Required:    lineage to check against, "auto" enables --auto-lineage instead
+    path busco_lineages_path              // Recommended: path to busco lineages - downloads if not set
+    path config_file                      // Optional:    busco configuration file
+
+    output:
+    tuple val(meta), path("*-busco.batch_summary.txt")                , emit: batch_summary
+    tuple val(meta), path("short_summary.*.txt")                      , emit: short_summaries_txt   , optional: true
+    tuple val(meta), path("short_summary.*.json")                     , emit: short_summaries_json  , optional: true
+    tuple val(meta), path("*-busco/*/run_*/full_table.tsv")           , emit: full_table            , optional: true
+    tuple val(meta), path("*-busco/*/run_*/missing_busco_list.tsv")   , emit: missing_busco_list    , optional: true
+    tuple val(meta), path("*-busco/*/run_*/single_copy_proteins.faa") , emit: single_copy_proteins  , optional: true
+    tuple val(meta), path("*-busco/*/run_*/busco_sequences")          , emit: seq_dir
+    tuple val(meta), path("*-busco/*/translated_proteins")            , emit: translated_dir        , optional: true
+    tuple val(meta), path("*-busco")                                  , emit: busco_dir
+    path "versions.yml"                                               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    if ( mode !in [ 'genome', 'proteins', 'transcriptome' ] ) {
+        error "Mode must be one of 'genome', 'proteins', or 'transcriptome'."
+    }
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta}-${lineage}"
+    def busco_config = config_file ? "--config $config_file" : ''
+    def busco_lineage = lineage.equals('auto') ? '--auto-lineage' : "--lineage_dataset ${lineage}"
+    def busco_lineage_dir = busco_lineages_path ? "--download_path ${busco_lineages_path}" : ''
+    """
+    # Nextflow changes the container --entrypoint to /bin/bash (container default entrypoint: /usr/local/env-execute)
+    # Check for container variable initialisation script and source it.
+    if [ -f "/usr/local/env-activate.sh" ]; then
+        set +u  # Otherwise, errors out because of various unbound variables
+        . "/usr/local/env-activate.sh"
+        set -u
+    fi
+
+    # If the augustus config directory is not writable, then copy to writeable area
+    if [ ! -w "\${AUGUSTUS_CONFIG_PATH}" ]; then
+        # Create writable tmp directory for augustus
+        AUG_CONF_DIR=\$( mktemp -d -p \$PWD )
+        cp -r \$AUGUSTUS_CONFIG_PATH/* \$AUG_CONF_DIR
+        export AUGUSTUS_CONFIG_PATH=\$AUG_CONF_DIR
+        echo "New AUGUSTUS_CONFIG_PATH=\${AUGUSTUS_CONFIG_PATH}"
+    fi
+
+    # Ensure the input is uncompressed
+    INPUT_SEQS=input_seqs
+    mkdir "\$INPUT_SEQS"
+    cd "\$INPUT_SEQS"
+    for FASTA in ../tmp_input/*; do
+        if [ "\${FASTA##*.}" == 'gz' ]; then
+            gzip -cdf "\$FASTA" > \$( basename "\$FASTA" .gz )
+        else
+            ln -s "\$FASTA" .
+        fi
+    done
+    cd ..
+
+    busco \\
+        --cpu $task.cpus \\
+        --in "\$INPUT_SEQS" \\
+        --out ${prefix}-busco \\
+        --mode $mode \\
+        $busco_lineage \\
+        $busco_lineage_dir \\
+        $busco_config \\
+        $args
+
+    # clean up
+    rm -rf "\$INPUT_SEQS"
+
+    # Move files to avoid staging/publishing issues
+    mv ${prefix}-busco/batch_summary.txt ${prefix}-busco.batch_summary.txt
+    mv ${prefix}-busco/*/short_summary.*.{json,txt} . || echo "Short summaries were not available: No genes were found."
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        busco: \$( busco --version 2>&1 | sed 's/^BUSCO //' )
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix      = task.ext.prefix ?: "${meta}-${lineage}"
+    def fasta_name  = files(fasta).first().name - '.gz'
+    """
+    touch ${prefix}-busco.batch_summary.txt
+    mkdir -p ${prefix}-busco/$fasta_name/run_${lineage}/busco_sequences
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        busco: \$( busco --version 2>&1 | sed 's/^BUSCO //' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/busco/busco/meta.yml
+++ b/modules/nf-core/busco/busco/meta.yml
@@ -1,0 +1,98 @@
+name: busco_busco
+description: Benchmarking Universal Single Copy Orthologs
+keywords:
+  - quality control
+  - genome
+  - transcriptome
+  - proteome
+tools:
+  - busco:
+      description: BUSCO provides measures for quantitative assessment of genome assembly, gene set, and transcriptome completeness based on evolutionarily informed expectations of gene content from near-universal single-copy orthologs selected from OrthoDB.
+      homepage: https://busco.ezlab.org/
+      documentation: https://busco.ezlab.org/busco_userguide.html
+      tool_dev_url: https://gitlab.com/ezlab/busco
+      doi: "10.1007/978-1-4939-9173-0_14"
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: Nucleic or amino acid sequence file in FASTA format.
+      pattern: "*.{fasta,fna,fa,fasta.gz,fna.gz,fa.gz}"
+  - mode:
+      type: string
+      description: The mode to run Busco in. One of genome, proteins, or transcriptome
+      pattern: "{genome,proteins,transcriptome}"
+  - lineage:
+      type: string
+      description: The BUSCO lineage to use, or "auto" to automatically select lineage
+  - busco_lineages_path:
+      type: directory
+      description: Path to local BUSCO lineages directory.
+  - config_file:
+      type: file
+      description: Path to BUSCO config file.
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - batch_summary:
+      type: file
+      description: Summary of all sequence files analyzed
+      pattern: "*-busco.batch_summary.txt"
+  - short_summaries_txt:
+      type: file
+      description: Short Busco summary in plain text format
+      pattern: "short_summary.*.txt"
+  - short_summaries_json:
+      type: file
+      description: Short Busco summary in JSON format
+      pattern: "short_summary.*.json"
+  - busco_dir:
+      type: directory
+      description: BUSCO lineage specific output
+      pattern: "*-busco"
+  - full_table:
+      type: file
+      description: Full BUSCO results table
+      pattern: "full_table.tsv"
+  - missing_busco_list:
+      type: file
+      description: List of missing BUSCOs
+      pattern: "missing_busco_list.tsv"
+  - single_copy_proteins:
+      type: file
+      description: Fasta file of single copy proteins (transcriptome mode)
+      pattern: "single_copy_proteins.faa"
+  - seq_dir:
+      type: directory
+      description: BUSCO sequence directory
+      pattern: "busco_sequences"
+  - translated_dir:
+      type: directory
+      description: Six frame translations of each transcript made by the transcriptome mode
+      pattern: "translated_dir"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@priyanka-surana"
+  - "@charles-plessy"
+  - "@mahesh-panchal"
+  - "@muffato"
+  - "@jvhagey"
+  - "@gallvp"
+maintainers:
+  - "@priyanka-surana"
+  - "@charles-plessy"
+  - "@mahesh-panchal"
+  - "@muffato"
+  - "@jvhagey"
+  - "@gallvp"

--- a/modules/nf-core/busco/busco/tests/main.nf.test
+++ b/modules/nf-core/busco/busco/tests/main.nf.test
@@ -1,0 +1,415 @@
+nextflow_process {
+
+    name "Test Process BUSCO_BUSCO"
+    script "../main.nf"
+    process "BUSCO_BUSCO"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "busco"
+    tag "busco/busco"
+
+    test("test_busco_genome_single_fasta") {
+
+        config './nextflow.config'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                ]
+                input[1] = 'genome'
+                input[2] = 'bacteria_odb10' // Launch with 'auto' to use --auto-lineage, and specified lineages // 'auto' removed from test due to memory issues
+                input[3] = [] // Download busco lineage
+                input[4] = [] // No config
+                """
+            }
+        }
+
+        then {
+            assert process.success
+
+            with(path(process.out.short_summaries_txt[0][1]).text) {
+                assert contains('BUSCO version')
+                assert contains('The lineage dataset is')
+                assert contains('BUSCO was run in mode')
+                assert contains('Complete BUSCOs')
+                assert contains('Missing BUSCOs')
+                assert contains('Dependencies and versions')
+            }
+
+            with(path(process.out.short_summaries_json[0][1]).text) {
+                assert contains('one_line_summary')
+                assert contains('mode')
+                assert contains('dataset')
+            }
+
+            assert snapshot(
+                    process.out.batch_summary[0][1],
+                    process.out.full_table[0][1],
+                    process.out.missing_busco_list[0][1],
+                    process.out.versions[0]
+                ).match()
+
+            with(file(process.out.seq_dir[0][1]).listFiles().collect { it.name }) {
+                assert contains('single_copy_busco_sequences.tar.gz')
+                assert contains('multi_copy_busco_sequences.tar.gz')
+                assert contains('fragmented_busco_sequences.tar.gz')
+            }
+
+            with(path("${process.out.busco_dir[0][1]}/logs/busco.log").text) {
+                assert contains('DEBUG:busco.run_BUSCO')
+                assert contains('Results from dataset')
+                assert contains('how to cite BUSCO')
+            }
+
+            assert process.out.single_copy_proteins == []
+            assert process.out.translated_dir == []
+        }
+    }
+
+    test("test_busco_genome_multi_fasta") {
+
+        config './nextflow.config'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/genome.fasta', checkIfExists: true)
+                    ]
+                ]
+                input[1] = 'genome'
+                input[2] = 'bacteria_odb10'
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+
+            with(path(process.out.short_summaries_txt[0][1][0]).text) {
+                assert contains('BUSCO version')
+                assert contains('The lineage dataset is')
+                assert contains('BUSCO was run in mode')
+                assert contains('Complete BUSCOs')
+                assert contains('Missing BUSCOs')
+                assert contains('Dependencies and versions')
+            }
+
+            with(path(process.out.short_summaries_txt[0][1][1]).text) {
+                assert contains('BUSCO version')
+                assert contains('The lineage dataset is')
+                assert contains('BUSCO was run in mode')
+                assert contains('Complete BUSCOs')
+                assert contains('Missing BUSCOs')
+                assert contains('Dependencies and versions')
+            }
+
+            with(path(process.out.short_summaries_json[0][1][0]).text) {
+                assert contains('one_line_summary')
+                assert contains('mode')
+                assert contains('dataset')
+            }
+
+            with(path(process.out.short_summaries_json[0][1][1]).text) {
+                assert contains('one_line_summary')
+                assert contains('mode')
+                assert contains('dataset')
+            }
+
+            assert snapshot(
+                    process.out.batch_summary[0][1],
+                    process.out.full_table[0][1],
+                    process.out.missing_busco_list[0][1],
+                    process.out.versions[0]
+                ).match()
+
+            with(file(process.out.seq_dir[0][1][0]).listFiles().collect { it.name }) {
+                assert contains('single_copy_busco_sequences.tar.gz')
+                assert contains('multi_copy_busco_sequences.tar.gz')
+                assert contains('fragmented_busco_sequences.tar.gz')
+            }
+
+            with(file(process.out.seq_dir[0][1][1]).listFiles().collect { it.name }) {
+                assert contains('single_copy_busco_sequences.tar.gz')
+                assert contains('multi_copy_busco_sequences.tar.gz')
+                assert contains('fragmented_busco_sequences.tar.gz')
+            }
+
+            with(path("${process.out.busco_dir[0][1]}/logs/busco.log").text) {
+                assert contains('DEBUG:busco.run_BUSCO')
+                assert contains('Results from dataset')
+                assert contains('how to cite BUSCO')
+            }
+
+            assert process.out.single_copy_proteins == []
+            assert process.out.translated_dir == []
+        }
+
+    }
+
+    test("test_busco_eukaryote_metaeuk") {
+
+        config './nextflow.metaeuk.config'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = 'genome'
+                input[2] = 'eukaryota_odb10'
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+
+            with(path(process.out.short_summaries_txt[0][1]).text) {
+                assert contains('BUSCO version')
+                assert contains('The lineage dataset is')
+                assert contains('BUSCO was run in mode')
+                assert contains('Complete BUSCOs')
+                assert contains('Missing BUSCOs')
+                assert contains('Dependencies and versions')
+            }
+
+            with(path(process.out.short_summaries_json[0][1]).text) {
+                assert contains('one_line_summary')
+                assert contains('mode')
+                assert contains('dataset')
+            }
+
+            assert snapshot(
+                    process.out.batch_summary[0][1],
+                    process.out.full_table[0][1],
+                    process.out.missing_busco_list[0][1],
+                    process.out.versions[0]
+                ).match()
+
+            with(file(process.out.seq_dir[0][1]).listFiles().collect { it.name }) {
+                assert contains('single_copy_busco_sequences.tar.gz')
+                assert contains('multi_copy_busco_sequences.tar.gz')
+                assert contains('fragmented_busco_sequences.tar.gz')
+            }
+
+            with(path("${process.out.busco_dir[0][1]}/logs/busco.log").text) {
+                assert contains('DEBUG:busco.run_BUSCO')
+                assert contains('Results from dataset')
+                assert contains('how to cite BUSCO')
+
+            }
+
+            assert process.out.single_copy_proteins == []
+            assert process.out.translated_dir == []
+        }
+
+    }
+
+    test("test_busco_eukaryote_augustus") {
+
+        config './nextflow.augustus.config'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = 'genome'
+                input[2] = 'eukaryota_odb10'
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+
+            assert snapshot(
+                    process.out.batch_summary[0][1],
+                    process.out.versions[0]
+                ).match()
+
+            with(path("${process.out.busco_dir[0][1]}/logs/busco.log").text) {
+                assert contains('DEBUG:busco.run_BUSCO')
+                assert contains('Augustus did not recognize any genes')
+
+            }
+
+            assert process.out.short_summaries_json == []
+            assert process.out.short_summaries_txt == []
+            assert process.out.missing_busco_list == []
+            assert process.out.full_table == []
+            assert process.out.single_copy_proteins == []
+            assert process.out.translated_dir == []
+        }
+
+    }
+
+    test("test_busco_protein") {
+
+        config './nextflow.config'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/proteome.fasta', checkIfExists: true)
+                ]
+                input[1] = 'proteins'
+                input[2] = 'bacteria_odb10'
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+
+            with(path(process.out.short_summaries_txt[0][1]).text) {
+                assert contains('BUSCO version')
+                assert contains('The lineage dataset is')
+                assert contains('BUSCO was run in mode')
+                assert contains('Complete BUSCOs')
+                assert contains('Missing BUSCOs')
+                assert contains('Dependencies and versions')
+            }
+
+            with(path(process.out.short_summaries_json[0][1]).text) {
+                assert contains('one_line_summary')
+                assert contains('mode')
+                assert contains('dataset')
+            }
+
+            assert snapshot(
+                    process.out.batch_summary[0][1],
+                    process.out.full_table[0][1],
+                    process.out.missing_busco_list[0][1],
+                    process.out.versions[0]
+                ).match()
+
+            with(file(process.out.seq_dir[0][1]).listFiles().collect { it.name }) {
+                assert contains('single_copy_busco_sequences.tar.gz')
+                assert contains('multi_copy_busco_sequences.tar.gz')
+                assert contains('fragmented_busco_sequences.tar.gz')
+            }
+
+            with(path("${process.out.busco_dir[0][1]}/logs/busco.log").text) {
+                assert contains('DEBUG:busco.run_BUSCO')
+                assert contains('Results from dataset')
+                assert contains('how to cite BUSCO')
+            }
+
+            assert process.out.single_copy_proteins == []
+            assert process.out.translated_dir == []
+        }
+
+    }
+
+    test("test_busco_transcriptome") {
+
+        config './nextflow.config'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/fasta/test1.contigs.fa.gz', checkIfExists: true)
+                ]
+                input[1] = 'transcriptome'
+                input[2] = 'bacteria_odb10'
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+
+            with(path(process.out.short_summaries_txt[0][1]).text) {
+                assert contains('BUSCO version')
+                assert contains('The lineage dataset is')
+                assert contains('BUSCO was run in mode')
+                assert contains('Complete BUSCOs')
+                assert contains('Missing BUSCOs')
+                assert contains('Dependencies and versions')
+            }
+
+            with(path(process.out.short_summaries_json[0][1]).text) {
+                assert contains('one_line_summary')
+                assert contains('mode')
+                assert contains('dataset')
+            }
+
+            assert snapshot(
+                    process.out.batch_summary[0][1],
+                    process.out.full_table[0][1],
+                    process.out.missing_busco_list[0][1],
+                    process.out.translated_dir[0][1],
+                    process.out.single_copy_proteins[0][1],
+                    process.out.versions[0]
+                ).match()
+
+            with(file(process.out.seq_dir[0][1]).listFiles().collect { it.name }) {
+                assert contains('single_copy_busco_sequences.tar.gz')
+                assert contains('multi_copy_busco_sequences.tar.gz')
+                assert contains('fragmented_busco_sequences.tar.gz')
+            }
+
+            with(path("${process.out.busco_dir[0][1]}/logs/busco.log").text) {
+                assert contains('DEBUG:busco.run_BUSCO')
+                assert contains('Results from dataset')
+                assert contains('how to cite BUSCO')
+            }
+        }
+
+    }
+
+    test("minimal-stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                ]
+                input[1] = 'genome'
+                input[2] = 'bacteria_odb10'
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/busco/busco/tests/main.nf.test.snap
+++ b/modules/nf-core/busco/busco/tests/main.nf.test.snap
@@ -1,0 +1,230 @@
+{
+    "minimal-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test-bacteria_odb10-busco.batch_summary.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "7": [
+                    
+                ],
+                "8": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            [
+                                [
+                                    [
+                                        
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                "9": [
+                    "versions.yml:md5,3fc94714b95c2dc15399a4229d9dd1d9"
+                ],
+                "batch_summary": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test-bacteria_odb10-busco.batch_summary.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "busco_dir": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            [
+                                [
+                                    [
+                                        
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                "full_table": [
+                    
+                ],
+                "missing_busco_list": [
+                    
+                ],
+                "seq_dir": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "short_summaries_json": [
+                    
+                ],
+                "short_summaries_txt": [
+                    
+                ],
+                "single_copy_proteins": [
+                    
+                ],
+                "translated_dir": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,3fc94714b95c2dc15399a4229d9dd1d9"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-03T13:28:04.451297"
+    },
+    "test_busco_eukaryote_augustus": {
+        "content": [
+            "test-eukaryota_odb10-busco.batch_summary.txt:md5,3ea3bdc423a461dae514d816bdc61c89",
+            "versions.yml:md5,3fc94714b95c2dc15399a4229d9dd1d9"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-03T13:26:36.974986"
+    },
+    "test_busco_genome_single_fasta": {
+        "content": [
+            "test-bacteria_odb10-busco.batch_summary.txt:md5,21b3fb771cf36be917cc451540d999be",
+            "full_table.tsv:md5,638fe7590f442c57361554dae330eca1",
+            "missing_busco_list.tsv:md5,1530af4fe7673a6d001349537bcd410a",
+            "versions.yml:md5,3fc94714b95c2dc15399a4229d9dd1d9"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-03T13:22:45.07816"
+    },
+    "test_busco_genome_multi_fasta": {
+        "content": [
+            "test-bacteria_odb10-busco.batch_summary.txt:md5,fcd3c208913e8abda3d6742c43fec5fa",
+            [
+                "full_table.tsv:md5,c657edcc7d0de0175869717551df6e83",
+                "full_table.tsv:md5,638fe7590f442c57361554dae330eca1"
+            ],
+            [
+                "missing_busco_list.tsv:md5,aceb66e347a353cb7fca8e2a725f9112",
+                "missing_busco_list.tsv:md5,1530af4fe7673a6d001349537bcd410a"
+            ],
+            "versions.yml:md5,3fc94714b95c2dc15399a4229d9dd1d9"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-03T13:23:50.255602"
+    },
+    "test_busco_eukaryote_metaeuk": {
+        "content": [
+            "test-eukaryota_odb10-busco.batch_summary.txt:md5,ff6d8277e452a83ce9456bbee666feb6",
+            "full_table.tsv:md5,92b1b1d5cb5ea0e2093d16f00187e8c7",
+            "missing_busco_list.tsv:md5,0352e563de290bf804c708323c35a9e3",
+            "versions.yml:md5,3fc94714b95c2dc15399a4229d9dd1d9"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-03T13:25:38.159041"
+    },
+    "test_busco_transcriptome": {
+        "content": [
+            "test-bacteria_odb10-busco.batch_summary.txt:md5,8734b3f379c4c0928e5dd4ea1873dc64",
+            "full_table.tsv:md5,1b2ce808fdafa744c56b5f781551272d",
+            "missing_busco_list.tsv:md5,a6931b6470262b997b8b99ea0f1d14a4",
+            [
+                "1024388at2.faa:md5,797d603d262a6595a112e25b73e878b0",
+                "1054741at2.faa:md5,cd4b928cba6b19b4437746ba507e7195",
+                "1093223at2.faa:md5,df9549708e5ffcfaee6a74dd70a0e5dc",
+                "1151822at2.faa:md5,12726afc1cdc40c13392e1596e93df3a",
+                "143460at2.faa:md5,d887431fd988a5556a523440f02d9594",
+                "1491686at2.faa:md5,d03362d19979b27306c192f1c74a84e5",
+                "1504821at2.faa:md5,4f5f6e5c57bac0092c1d85ded73d7e67",
+                "1574817at2.faa:md5,1153e55998c2929eacad2aed7d08d248",
+                "1592033at2.faa:md5,bb7a59e5f3a57ba12d10dabf4c77ab57",
+                "1623045at2.faa:md5,8fe38155feb1802beb97ef7714837bf5",
+                "1661836at2.faa:md5,6c6d592c2fbb0d7a4e5e1f47a15644f0",
+                "1674344at2.faa:md5,bb41b44e53565a54cadf0b780532fe08",
+                "1698718at2.faa:md5,f233860000028eb00329aa85236c71e5",
+                "1990650at2.faa:md5,34a2d29c5f8b6253159ddb7a43fa1829",
+                "223233at2.faa:md5,dec6705c7846c989296e73942f953cbc",
+                "402899at2.faa:md5,acc0f271f9a586d2ce1ee41669b22999",
+                "505485at2.faa:md5,aa0391f8fa5d9bd19b30d844d5a99845",
+                "665824at2.faa:md5,47f8ad43b6a6078206feb48c2e552793",
+                "776861at2.faa:md5,f8b90c13f7c6be828dea3bb920195e3d",
+                "874197at2.faa:md5,8d22a35a768debe6f376fc695d233a69",
+                "932854at2.faa:md5,2eff2de1ab83b22f3234a529a44e22bb",
+                "95696at2.faa:md5,247bfd1aef432f7b5456307768e9149c"
+            ],
+            "single_copy_proteins.faa:md5,73e2c5d6a9b0f01f2deea3cc5f21b764",
+            "versions.yml:md5,3fc94714b95c2dc15399a4229d9dd1d9"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-03T13:27:53.992893"
+    },
+    "test_busco_protein": {
+        "content": [
+            "test-bacteria_odb10-busco.batch_summary.txt:md5,f5a782378f9f94a748aa907381fdef91",
+            "full_table.tsv:md5,812ab6a0496fccab774643cf40c4f2a8",
+            "missing_busco_list.tsv:md5,aceb66e347a353cb7fca8e2a725f9112",
+            "versions.yml:md5,3fc94714b95c2dc15399a4229d9dd1d9"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-03T13:27:12.724862"
+    }
+}

--- a/modules/nf-core/busco/busco/tests/nextflow.augustus.config
+++ b/modules/nf-core/busco/busco/tests/nextflow.augustus.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'BUSCO_BUSCO' {
+        ext.args = '--tar --augustus'
+    }
+}

--- a/modules/nf-core/busco/busco/tests/nextflow.config
+++ b/modules/nf-core/busco/busco/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'BUSCO_BUSCO' {
+        ext.args = '--tar'
+    }
+}

--- a/modules/nf-core/busco/busco/tests/nextflow.metaeuk.config
+++ b/modules/nf-core/busco/busco/tests/nextflow.metaeuk.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'BUSCO_BUSCO' {
+        ext.args = '--tar --metaeuk'
+    }
+}

--- a/modules/nf-core/busco/busco/tests/old_test.yml
+++ b/modules/nf-core/busco/busco/tests/old_test.yml
@@ -1,0 +1,624 @@
+- name: busco test_busco_genome_single_fasta
+  command: nextflow run ./tests/modules/nf-core/busco -entry test_busco_genome_single_fasta -c ./tests/config/nextflow.config
+  tags:
+    - busco
+  files:
+    - path: output/busco/short_summary.specific.bacteria_odb10.genome.fna.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/short_summary.specific.bacteria_odb10.genome.fna.txt
+      contains:
+        - "BUSCO version"
+        - "The lineage dataset is"
+        - "BUSCO was run in mode"
+        - "Complete BUSCOs"
+        - "Missing BUSCOs"
+        - "Dependencies and versions"
+    - path: output/busco/test-bacteria_odb10-busco.batch_summary.txt
+      md5sum: bc2440f8a68d7fbf931ff911c1c3fdfa
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/bbtools_err.log
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/bbtools_out.log
+      md5sum: 9caf1a1434414c78562eb0bbb9c0e53f
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/hmmsearch_err.log
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/hmmsearch_out.log
+      contains:
+        - "# hmmsearch :: search profile(s) against a sequence database"
+        - "# target sequence database:"
+        - "Internal pipeline statistics summary:"
+        - "[ok]"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/prodigal_err.log
+      md5sum: 538510cfc7483498210f01e53fe035ad
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/prodigal_out.log
+      md5sum: 61050b0706addc9498b2088a2d6efa9a
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/.checkpoint
+      contains:
+        - "Tool: prodigal"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/predicted.faa
+      md5sum: 836e9a80d33d8b89168f07ddc13ee991
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/predicted.fna
+      md5sum: 20eeb75f86842e6e136f02bca8b73a9f
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11.faa
+      md5sum: 836e9a80d33d8b89168f07ddc13ee991
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11.fna
+      md5sum: 20eeb75f86842e6e136f02bca8b73a9f
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11_err.log
+      md5sum: 538510cfc7483498210f01e53fe035ad
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11_out.log
+      md5sum: 61050b0706addc9498b2088a2d6efa9a
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/.bbtools_output/.checkpoint
+      contains:
+        - "Tool: bbtools"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/busco_sequences/fragmented_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/busco_sequences/multi_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/busco_sequences/single_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/full_table.tsv
+      md5sum: c56edab1dc1522e993c25ae2b730799f
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/hmmer_output.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/missing_busco_list.tsv
+      md5sum: b533ef30270f27160acce85a22d01bf5
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/short_summary.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "lineage_dataset"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/short_summary.txt
+      contains:
+        - "# BUSCO version is:"
+        - "Results:"
+        - "busco:"
+    - path: output/busco/test-bacteria_odb10-busco/logs/busco.log
+      contains:
+        - "DEBUG:busco.run_BUSCO"
+        - "Results from dataset"
+        - "how to cite BUSCO"
+    - path: output/busco/versions.yml
+
+- name: busco test_busco_genome_multi_fasta
+  command: nextflow run ./tests/modules/nf-core/busco -entry test_busco_genome_multi_fasta -c ./tests/config/nextflow.config
+  tags:
+    - busco
+  files:
+    - path: output/busco/short_summary.specific.bacteria_odb10.genome.fasta.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/short_summary.specific.bacteria_odb10.genome.fasta.txt
+      contains:
+        - "BUSCO version"
+        - "The lineage dataset is"
+        - "BUSCO was run in mode"
+        - "Complete BUSCOs"
+        - "Missing BUSCOs"
+        - "Dependencies and versions"
+    - path: output/busco/short_summary.specific.bacteria_odb10.genome.fna.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/short_summary.specific.bacteria_odb10.genome.fna.txt
+      contains:
+        - "BUSCO version"
+        - "The lineage dataset is"
+        - "BUSCO was run in mode"
+        - "Complete BUSCOs"
+        - "Missing BUSCOs"
+        - "Dependencies and versions"
+    - path: output/busco/test-bacteria_odb10-busco.batch_summary.txt
+      md5sum: 8c64c1a28b086ef2ee444f99cbed5f7d
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/logs/bbtools_err.log
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/logs/bbtools_out.log
+      md5sum: 8f047bdb33264d22a83920bc2c63f29a
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/logs/hmmsearch_err.log
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/logs/hmmsearch_out.log
+      contains:
+        - "# hmmsearch :: search profile(s) against a sequence database"
+        - "# target sequence database:"
+        - "Internal pipeline statistics summary:"
+        - "[ok]"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/logs/prodigal_err.log
+      md5sum: c1fdc6977332f53dfe7f632733bb4585
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/logs/prodigal_out.log
+      md5sum: 50752acb1c5a20be886bfdfc06635bcb
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/.checkpoint
+      contains:
+        - "Tool: prodigal"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/predicted.faa
+      md5sum: 8166471fc5f08c82fd5643ab42327f9d
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/predicted.fna
+      md5sum: ddc508a18f60e7f3314534df50cdf8ca
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11.faa
+      md5sum: 8166471fc5f08c82fd5643ab42327f9d
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11.fna
+      md5sum: ddc508a18f60e7f3314534df50cdf8ca
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11_err.log
+      md5sum: c1fdc6977332f53dfe7f632733bb4585
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11_out.log
+      md5sum: 50752acb1c5a20be886bfdfc06635bcb
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_4.faa
+      md5sum: e56fd59c38248dc21ac94355dca98121
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_4.fna
+      md5sum: b365f84bf99c68357952e0b98ed7ce42
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_4_err.log
+      md5sum: e5f14d7925ba14a0f9850542f3739894
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_4_out.log
+      md5sum: d41971bfc1b621d4ffd2633bc47017ea
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/run_bacteria_odb10/.bbtools_output/.checkpoint
+      contains:
+        - "Tool: bbtools"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/run_bacteria_odb10/busco_sequences/fragmented_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/run_bacteria_odb10/busco_sequences/multi_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/run_bacteria_odb10/busco_sequences/single_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/run_bacteria_odb10/full_table.tsv
+      md5sum: c9651b88b10871abc260ee655898e828
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/run_bacteria_odb10/hmmer_output.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/run_bacteria_odb10/missing_busco_list.tsv
+      md5sum: 9939309df2da5419de88c32d1435c779
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/run_bacteria_odb10/short_summary.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fasta/run_bacteria_odb10/short_summary.txt
+      contains:
+        - "# BUSCO version is:"
+        - "Results:"
+        - "busco:"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/bbtools_err.log
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/bbtools_out.log
+      md5sum: 9caf1a1434414c78562eb0bbb9c0e53f
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/hmmsearch_err.log
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/hmmsearch_out.log
+      contains:
+        - "# hmmsearch :: search profile(s) against a sequence database"
+        - "# target sequence database:"
+        - "Internal pipeline statistics summary:"
+        - "[ok]"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/prodigal_err.log
+      md5sum: 538510cfc7483498210f01e53fe035ad
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/logs/prodigal_out.log
+      md5sum: 61050b0706addc9498b2088a2d6efa9a
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/.checkpoint
+      contains:
+        - "Tool: prodigal"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/predicted.faa
+      md5sum: 836e9a80d33d8b89168f07ddc13ee991
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/predicted.fna
+      md5sum: 20eeb75f86842e6e136f02bca8b73a9f
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11.faa
+      md5sum: 836e9a80d33d8b89168f07ddc13ee991
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11.fna
+      md5sum: 20eeb75f86842e6e136f02bca8b73a9f
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11_err.log
+      md5sum: 538510cfc7483498210f01e53fe035ad
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/prodigal_output/predicted_genes/tmp/prodigal_mode_single_code_11_out.log
+      md5sum: 61050b0706addc9498b2088a2d6efa9a
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/.bbtools_output/.checkpoint
+      contains:
+        - "Tool: bbtools"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/busco_sequences/fragmented_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/busco_sequences/multi_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/busco_sequences/single_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/full_table.tsv
+      md5sum: c56edab1dc1522e993c25ae2b730799f
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/hmmer_output.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/missing_busco_list.tsv
+      md5sum: b533ef30270f27160acce85a22d01bf5
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/short_summary.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/test-bacteria_odb10-busco/genome.fna/run_bacteria_odb10/short_summary.txt
+      contains:
+        - "# BUSCO version is:"
+        - "Results:"
+        - "busco:"
+    - path: output/busco/test-bacteria_odb10-busco/logs/busco.log
+      contains:
+        - "DEBUG:busco.run_BUSCO"
+        - "Results from dataset"
+        - "how to cite BUSCO"
+    - path: output/busco/versions.yml
+
+- name: busco test_busco_eukaryote_metaeuk
+  command: nextflow run ./tests/modules/nf-core/busco -entry test_busco_eukaryote_metaeuk -c ./tests/config/nextflow.config
+  tags:
+    - busco
+  files:
+    - path: output/busco/short_summary.specific.eukaryota_odb10.genome.fasta.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/short_summary.specific.eukaryota_odb10.genome.fasta.txt
+      contains:
+        - "BUSCO version"
+        - "The lineage dataset is"
+        - "BUSCO was run in mode"
+        - "Complete BUSCOs"
+        - "Missing BUSCOs"
+        - "Dependencies and versions"
+    - path: output/busco/test-eukaryota_odb10-busco.batch_summary.txt
+      md5sum: ff6d8277e452a83ce9456bbee666feb6
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/bbtools_err.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/bbtools_out.log
+      md5sum: e63debaa653f18f7405d936050abc093
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/hmmsearch_err.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/hmmsearch_out.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/metaeuk_run1_err.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/metaeuk_run1_out.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/metaeuk_run2_err.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/metaeuk_run2_out.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/.bbtools_output/.checkpoint
+      contains:
+        - "Tool: bbtools"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/busco_sequences/fragmented_busco_sequences.tar.gz
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/busco_sequences/multi_copy_busco_sequences.tar.gz
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/busco_sequences/single_copy_busco_sequences.tar.gz
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/full_table.tsv
+      md5sum: bd880e90b9e5620a58943a3e0f9ff16b
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/hmmer_output.tar.gz
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/.checkpoint
+      contains:
+        - "Tool: metaeuk"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/combined_pred_proteins.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/initial_results/genome.fasta.codon.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/initial_results/genome.fasta.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/initial_results/genome.fasta.gff
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/initial_results/genome.fasta.headersMap.tsv
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/refseq_db_rerun.faa
+      md5sum: d80b8fa4cb5ed0d47d63d6aa93635bc2
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/rerun_results/genome.fasta.codon.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/rerun_results/genome.fasta.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/rerun_results/genome.fasta.gff
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/rerun_results/genome.fasta.headersMap.tsv
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/missing_busco_list.tsv
+      md5sum: 1e8e79c540fd2e69ba0d2659d9eb2988
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/short_summary.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/short_summary.txt
+      contains:
+        - "# BUSCO version is:"
+        - "Results:"
+        - "busco:"
+    - path: output/busco/test-eukaryota_odb10-busco/logs/busco.log
+      contains:
+        - "DEBUG:busco.run_BUSCO"
+        - "Results from dataset"
+        - "how to cite BUSCO"
+    - path: output/busco/versions.yml
+
+- name: busco test_busco_eukaryote_augustus
+  command: nextflow run ./tests/modules/nf-core/busco -entry test_busco_eukaryote_augustus -c ./tests/config/nextflow.config
+  tags:
+    - busco
+  files:
+    - path: output/busco/short_summary.specific.eukaryota_odb10.genome.fasta.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/short_summary.specific.eukaryota_odb10.genome.fasta.txt
+      contains:
+        - "BUSCO version"
+        - "The lineage dataset is"
+        - "BUSCO was run in mode"
+        - "Complete BUSCOs"
+        - "Missing BUSCOs"
+        - "Dependencies and versions"
+    - path: output/busco/test-eukaryota_odb10-busco.batch_summary.txt
+      md5sum: ff6d8277e452a83ce9456bbee666feb6
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/bbtools_err.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/bbtools_out.log
+      md5sum: e63debaa653f18f7405d936050abc093
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/hmmsearch_err.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/hmmsearch_out.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/metaeuk_run1_err.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/metaeuk_run1_out.log
+      contains:
+        - "metaeuk"
+        - "easy-predict"
+        - "Compute score and coverage"
+        - "Time for processing:"
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/metaeuk_run2_err.log
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/logs/metaeuk_run2_out.log
+      contains:
+        - "metaeuk"
+        - "easy-predict"
+        - "Compute score and coverage"
+        - "Time for processing:"
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/.bbtools_output/.checkpoint
+      contains:
+        - "Tool: bbtools"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/busco_sequences/fragmented_busco_sequences.tar.gz
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/busco_sequences/multi_copy_busco_sequences.tar.gz
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/busco_sequences/single_copy_busco_sequences.tar.gz
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/full_table.tsv
+      md5sum: bd880e90b9e5620a58943a3e0f9ff16b
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/hmmer_output.tar.gz
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/.checkpoint
+      contains:
+        - "Tool: metaeuk"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/combined_pred_proteins.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/initial_results/genome.fasta.codon.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/initial_results/genome.fasta.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/initial_results/genome.fasta.gff
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/initial_results/genome.fasta.headersMap.tsv
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/refseq_db_rerun.faa
+      md5sum: d80b8fa4cb5ed0d47d63d6aa93635bc2
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/rerun_results/genome.fasta.codon.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/rerun_results/genome.fasta.fas
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/rerun_results/genome.fasta.gff
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/metaeuk_output/rerun_results/genome.fasta.headersMap.tsv
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/missing_busco_list.tsv
+      md5sum: 1e8e79c540fd2e69ba0d2659d9eb2988
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/short_summary.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/test-eukaryota_odb10-busco/genome.fasta/run_eukaryota_odb10/short_summary.txt
+      contains:
+        - "# BUSCO version is:"
+        - "Results:"
+        - "busco:"
+    - path: output/busco/test-eukaryota_odb10-busco/logs/busco.log
+      contains:
+        - "DEBUG:busco.run_BUSCO"
+        - "Results from dataset"
+        - "how to cite BUSCO"
+    - path: output/busco/versions.yml
+
+- name: busco test_busco_protein
+  command: nextflow run ./tests/modules/nf-core/busco -entry test_busco_protein -c ./tests/config/nextflow.config
+  tags:
+    - busco
+  files:
+    - path: output/busco/short_summary.specific.bacteria_odb10.proteome.fasta.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/short_summary.specific.bacteria_odb10.proteome.fasta.txt
+      contains:
+        - "BUSCO version"
+        - "The lineage dataset is"
+        - "BUSCO was run in mode"
+        - "Complete BUSCOs"
+        - "Missing BUSCOs"
+        - "Dependencies and versions"
+    - path: output/busco/test-bacteria_odb10-busco.batch_summary.txt
+      md5sum: 7a65e6cbb6c56a2ea4e739ae0aa3297d
+    - path: output/busco/test-bacteria_odb10-busco/logs/busco.log
+      contains:
+        - "DEBUG:busco.run_BUSCO"
+        - "Results from dataset"
+        - "how to cite BUSCO"
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/logs/hmmsearch_err.log
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/logs/hmmsearch_out.log
+      contains:
+        - "# hmmsearch :: search profile(s) against a sequence database"
+        - "# target sequence database:"
+        - "Internal pipeline statistics summary:"
+        - "[ok]"
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/run_bacteria_odb10/busco_sequences/fragmented_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/run_bacteria_odb10/busco_sequences/multi_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/run_bacteria_odb10/busco_sequences/single_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/run_bacteria_odb10/full_table.tsv
+      md5sum: 0e34f1011cd83ea1d5d5103ec62b8922
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/run_bacteria_odb10/hmmer_output.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/run_bacteria_odb10/missing_busco_list.tsv
+      md5sum: 9939309df2da5419de88c32d1435c779
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/run_bacteria_odb10/short_summary.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/test-bacteria_odb10-busco/proteome.fasta/run_bacteria_odb10/short_summary.txt
+      contains:
+        - "# BUSCO version is:"
+        - "Results:"
+        - "busco:"
+    - path: output/busco/versions.yml
+
+- name: busco test_busco_transcriptome
+  command: nextflow run ./tests/modules/nf-core/busco -entry test_busco_transcriptome -c ./tests/config/nextflow.config
+  tags:
+    - busco
+  files:
+    - path: output/busco/short_summary.specific.bacteria_odb10.test1.contigs.fa.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/short_summary.specific.bacteria_odb10.test1.contigs.fa.txt
+      contains:
+        - "BUSCO version"
+        - "The lineage dataset is"
+        - "BUSCO was run in mode"
+        - "Complete BUSCOs"
+        - "Missing BUSCOs"
+        - "Dependencies and versions"
+    - path: output/busco/test-bacteria_odb10-busco.batch_summary.txt
+      md5sum: 46118ecf60d1b87d22b96d80f4f03632
+    - path: output/busco/test-bacteria_odb10-busco/logs/busco.log
+      contains:
+        - "DEBUG:busco.run_BUSCO"
+        - "Results from dataset"
+        - "how to cite BUSCO"
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/blast_db/.checkpoint
+      contains:
+        - "Tool: makeblastdb"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/blast_db/test1.contigs.fa.ndb
+      md5sum: 3788c017fe5e6f0f58224e9cdd21822b
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/blast_db/test1.contigs.fa.nhr
+      md5sum: 8ecd2ce392bb5e25ddbe1d85f879582e
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/blast_db/test1.contigs.fa.nin
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/blast_db/test1.contigs.fa.njs
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/blast_db/test1.contigs.fa.not
+      md5sum: 0c340e376c7e85d19f82ec1a833e6a6e
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/blast_db/test1.contigs.fa.nsq
+      md5sum: 532d5c0a7ea00fe95ca3c97cb3be6198
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/blast_db/test1.contigs.fa.ntf
+      md5sum: de1250813f0c7affc6d12dac9d0fb6bb
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/blast_db/test1.contigs.fa.nto
+      md5sum: ff74bd41f9cc9b011c63a32c4f7693bf
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/logs/hmmsearch_err.log
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/logs/hmmsearch_out.log
+      contains:
+        - "# hmmsearch :: search profile(s) against a sequence database"
+        - "# target sequence database:"
+        - "Internal pipeline statistics summary:"
+        - "[ok]"
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/logs/makeblastdb_err.log
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/logs/makeblastdb_out.log
+      contains:
+        - "Building a new DB"
+        - "Adding sequences from FASTA"
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/logs/tblastn_err.log
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/logs/tblastn_out.log
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/.checkpoint
+      contains:
+        - "Tool: tblastn"
+        - "Completed"
+        - "jobs"
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/coordinates.tsv
+      md5sum: cc30eed321944af293452bdbcfc24292
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_101.temp
+      md5sum: 73e9c65fc83fedc58f57f09b08f08238
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_119.temp
+      md5sum: 7fa4cc7955ec0cc36330a221c579b975
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_129.temp
+      md5sum: 6f1601c875d019e3f6f1f98ed8e988d4
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_138.temp
+      md5sum: 3f8e034686cd240c2330650d791bcae2
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_143.temp
+      md5sum: df3dfa8e9ba30ed70cf75b5e7abf2179
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_172.temp
+      md5sum: 7d463e0e6cf7169bc9077d8dc776dda1
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_178.temp
+      md5sum: 2288edf7fa4f88f51b4cf4d94086f77e
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_188.temp
+      md5sum: 029906abbad6d87fc57830dd548cac24
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_195.temp
+      md5sum: 4937f3b348774a31b1160a00297c29cc
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_210.temp
+      md5sum: afcb20ba4c466479d6b91c8c62251e1f
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_232.temp
+      md5sum: 2e1e823ce017345bd998191a39fa9924
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_268.temp
+      md5sum: 08c2d82c34ecffbe1c638b410349412e
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_29.temp
+      md5sum: cd9b63cf93524284781535c888313764
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_44.temp
+      md5sum: d1929b742b24ebe379bf4801ca882dca
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_58.temp
+      md5sum: 69215765b010c05336538cb322c900b3
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_72.temp
+      md5sum: 6feaa1cc3b0899a147ea9d466878f3e3
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_80.temp
+      md5sum: 13625eae14e860a96ce17cd4e37e9d01
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_81.temp
+      md5sum: e14b2484649b0dbc8926815c207b806d
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_93.temp
+      md5sum: 6902c93691df00e690faea914c71839e
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/sequences/k141_97.temp
+      md5sum: 0a0d9d38a83acbd5ad43c29cdf429988
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/blast_output/tblastn.tsv
+      contains:
+        - "TBLASTN"
+        - "BLAST processed"
+        - "queries"
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/busco_sequences/fragmented_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/busco_sequences/multi_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/busco_sequences/single_copy_busco_sequences.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/full_table.tsv
+      md5sum: 24df25199e13c88bd892fc3e7b541ca0
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/hmmer_output.tar.gz
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/missing_busco_list.tsv
+      md5sum: e7232e2b8cca4fdfdd9e363b39ebbc81
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/short_summary.json
+      contains:
+        - "one_line_summary"
+        - "mode"
+        - "dataset"
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/short_summary.txt
+      contains:
+        - "# BUSCO version is:"
+        - "Results:"
+        - "busco:"
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/run_bacteria_odb10/single_copy_proteins.faa
+      md5sum: e04b9465733577ae6e4bccb7aa01e720
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1024388at2.faa
+      md5sum: 7333c39a20258f20c7019ea0cd83157c
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1054741at2.faa
+      md5sum: ebb481e77a824685fbe04d8a2f3a0d7d
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1093223at2.faa
+      md5sum: 34621c7d499034e8f8e6b92fd4020a93
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1151822at2.faa
+      md5sum: aa89ca381c1c70c9c4e1380351ca7c2a
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/143460at2.faa
+      md5sum: f2e91d78b8dd3722840378789f29e8c8
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1491686at2.faa
+      md5sum: 73c25aef5c9cba7f4151804941b146ea
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1504821at2.faa
+      md5sum: cda556018d1f84ebe517e89f6fc107d0
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1574817at2.faa
+      md5sum: a9096c9fb8b25c78a72871ab0463acdc
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1592033at2.faa
+      md5sum: e463d25ce186c0cebfd749474f3a4c64
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1623045at2.faa
+      md5sum: f2cfd241590c6d8377286d6135480937
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1661836at2.faa
+      md5sum: 586569546fb9861502468e3d9ba2775c
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1674344at2.faa
+      md5sum: 24c658bee14ad84b062d81ad96642eb8
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1698718at2.faa
+      md5sum: 0b8e26ddf5149bbd8805be7af125208d
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/1990650at2.faa
+      md5sum: 159320712ee01fb2ccb31a25df44eead
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/223233at2.faa
+      md5sum: 812629c0b06ac3d18661c2ca78de0c08
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/402899at2.faa
+      md5sum: f7ff4e1591342d30b77392a2e84b57d9
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/505485at2.faa
+      md5sum: 7b34a24fc49c540d46fcf96ff5129564
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/665824at2.faa
+      md5sum: 4cff2df64f6bcaff8bc19c234c8bcccd
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/776861at2.faa
+      md5sum: 613af7a3fea30ea2bece66f603b9284a
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/874197at2.faa
+      md5sum: a7cd1b13c9ef91c7ef4e31614166f197
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/932854at2.faa
+      md5sum: fe313ffd5efdb0fed887a04fba352552
+    - path: output/busco/test-bacteria_odb10-busco/test1.contigs.fa/translated_proteins/95696at2.faa
+      md5sum: 4e1f30a2fea4dfbf9bb7fae2700622a0
+    - path: output/busco/versions.yml

--- a/modules/nf-core/busco/busco/tests/tags.yml
+++ b/modules/nf-core/busco/busco/tests/tags.yml
@@ -1,0 +1,2 @@
+busco/busco:
+  - "modules/nf-core/busco/busco/**"

--- a/modules/nf-core/busco/environment.yml
+++ b/modules/nf-core/busco/environment.yml
@@ -1,0 +1,7 @@
+name: busco_busco
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::busco=5.7.1

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,6 +35,13 @@ params {
   help = null
   // nf-core module parameters
   publish_dir_mode           = 'copy'
+
+    // BUSCO options
+    busco_mode                 = 'proteins'
+    busco_lineage              = 'auto'
+    busco_lineages_path        = null
+    busco_config               = null
+
 }
 
 plugins {

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,12 +35,12 @@ params {
   help = null
   // nf-core module parameters
   publish_dir_mode           = 'copy'
-
-    // BUSCO options
-    busco_mode                 = 'proteins'
-    busco_lineage              = 'auto'
-    busco_lineages_path        = null
-    busco_config               = null
+  // BUSCO options
+  busco                      = null
+  busco_mode                 = 'proteins'
+  busco_lineage              = 'auto'
+  busco_lineages_path        = null
+  busco_config               = null
 
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -89,7 +89,6 @@
         },
         "clean": {
           "type": "boolean",
-          "default": false,
           "description": "Enable cleanup function"
         },
         "architecture": {
@@ -114,7 +113,8 @@
           "description": "A path to a file containing a list of ensembl biomart dataset names separated by newline"
         },
         "ensembl_biomart": {
-          "type": "string"
+          "type": "string",
+          "description": "A biomart choice (e.g. ensembl)"
         },
         "predownloaded_fasta": {
           "type": "string",
@@ -138,13 +138,12 @@
         },
         "busco": {
           "type": "boolean",
-          "default": false,
-          "description": "Choose whether to run busco or not" 
-        },        
+          "description": "Choose whether to run busco or not"
+        },
         "busco_mode": {
           "type": "string",
           "default": "proteins",
-          "description": "A flag to set the busco mode. Either genome, proteins, transcriptome" 
+          "description": "A flag to set the busco mode. Either genome, proteins, transcriptome"
         },
         "busco_lineage": {
           "type": "string",
@@ -153,12 +152,10 @@
         },
         "busco_lineages_path": {
           "type": "string",
-          "default": null,
           "description": "A flag to set the BUSCO lineages directory"
         },
         "busco_config": {
           "type": "string",
-          "default": null,
           "description": "A path to a BUSCO config file (optional)"
         }
       }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -135,6 +135,31 @@
         "skip_cafe": {
           "type": "boolean",
           "description": "A flag to skip the cafe section. Used if you just wish to run go assignment for a species without runnig Cafe"
+        },
+        "busco": {
+          "type": "boolean",
+          "default": false,
+          "description": "Choose whether to run busco or not" 
+        },        
+        "busco_mode": {
+          "type": "string",
+          "default": "proteins",
+          "description": "A flag to set the busco mode. Either genome, proteins, transcriptome" 
+        },
+        "busco_lineage": {
+          "type": "string",
+          "default": "auto",
+          "description": "A flag to set the busco lineage, default:auto"
+        },
+        "busco_lineages_path": {
+          "type": "string",
+          "default": null,
+          "description": "A flag to set the BUSCO lineages directory"
+        },
+        "busco_config": {
+          "type": "string",
+          "default": null,
+          "description": "A path to a BUSCO config file (optional)"
         }
       }
     }


### PR DESCRIPTION
Added busco to the excon pipeline. from nf-core. It will tell us how complete the genome is. 

It should now run with the optional flag --busco and will run busco on all the genomes and save the results to ./results/busco

It can be run with the following command:
`nextflow run main.nf -resume -profile docker,test_small --busco`

You have additional flags to set when running busco:
  // BUSCO options
  busco                      = null    #if we want to run busco or not
  busco_mode                 = 'proteins'   # can also run from nucleotide or genome.
  busco_lineage              = 'auto'          # which lineage to compare to , or automatic
  busco_lineages_path        = null       #need to look up the docs of when you want this and next flag,,, just default from nf-core busco
  busco_config               = null