### PR TITLE
Add weight01_fisher go_algo option; document score-based statistic pi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - New `CAFE_PLOT_ALTVIZ` module: alternative species-tree figures restricted to statistically significant families — `cafe_sig_hog_tree` (significantly expanded/contracted family counts per branch) and `cafe_sig_gene_tree` (net genes gained/lost per branch). Produced only when GO enrichment runs, as they depend on `CAFE_summary.txt`.
 - New `CAFE_NODE_GUIDE` module: prints a node-label guide tree (`cafe_node_label_guide.pdf/svg`) so the numbered internal nodes in the CAFE figures can be matched to lineages.
 - New `docs/zenodo_cafe_readme.md` explaining the CAFE output files for archived/published datasets.
+- New `--go_algo weight01_fisher` option: runs topGO's hierarchy-aware `weight01` algorithm with the `fisher` statistic, giving less redundant enrichment than `classic_fisher` while remaining compatible with the gene-list input. Added to `ChopGO_VTS2.pl`, `ChopGO_ChromoGoatee.pl`, and the schema.
 
 ### Changed
 - GO plot figures now use the Cairo device and are output in both PDF and SVG (plus PNG), making them easier to edit in tools like Inkscape for journal publication.
@@ -21,6 +22,7 @@
 ### Fixed
 - `SUMMARIZE_CAFE_GO` / GO summary step no longer fails when there are no significant GO hits.
 - Fixed execute permissions (chmod) on the new R scripts and corrected the path to R in the summarize step.
+- Documented that `--go_algo` values using score-based statistics (`weight01_t`, `elim_ks`, `weight_ks`) silently produce empty GO tables, because the CAFE/chromosome GO input is a gene membership list (a 0/1 factor) and the `t`/`ks` statistics require per-gene numeric scores. The R error does not propagate (output is optional), so the pipeline completes "successfully" with no GO results. Use `classic_fisher` or the new `weight01_fisher` instead. Warning added to the `-go_algo` help text and schema.
 
 ## [v2.3.1] - 2026-04-12
 

--- a/bin/ChopGO_ChromoGoatee.pl
+++ b/bin/ChopGO_ChromoGoatee.pl
@@ -85,7 +85,10 @@ plotting options:
     -min_genes_req   Choose minimum number of genes containing each GO term. Default=2.
     -max_genes_req   Choose maximum number of genes containing each GO term. Default=100000.
     -allow_inferred  Allow inferred parent (GO, not in original file) into final enrichment. Default=0=OFF.
-    -go_algo         topGO algorithm and statistic: classic_fisher (default), weight01_t, elim_ks, weight_ks.
+    -go_algo         topGO algorithm and statistic: classic_fisher (default), weight01_fisher, weight01_t, elim_ks, weight_ks.
+                     NOTE: weight01_t, elim_ks and weight_ks use score-based statistics (t/ks) which require
+                     per-gene numeric scores. The CAFE/chromosome GO input is a gene membership list, so only
+                     the Fisher-based options (classic_fisher, weight01_fisher) produce results with this input.
     -plot_only       Plot Only (BOOLEAN, optional), don't do GO enrichments. Default=0=OFF.
     -open_plot       Open plots once made (BOOLEAN, optional). Default=0=OFF.
 
@@ -150,7 +153,8 @@ my @ALL_made_files;
 my @methods=("holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none");
 
 my ($algo, $stat);
-if    ($go_algo eq "weight01_t") { $algo = "weight01"; $stat = "t"; }
+if    ($go_algo eq "weight01_fisher") { $algo = "weight01"; $stat = "fisher"; }
+elsif ($go_algo eq "weight01_t") { $algo = "weight01"; $stat = "t"; }
 elsif ($go_algo eq "elim_ks")    { $algo = "elim";     $stat = "ks"; }
 elsif ($go_algo eq "weight_ks")  { $algo = "weight";   $stat = "ks"; }
 else                             { $algo = "classic";  $stat = "fisher"; }

--- a/bin/ChopGO_VTS2.pl
+++ b/bin/ChopGO_VTS2.pl
@@ -85,7 +85,10 @@ plotting options:
     -min_genes_req   Choose minimum number of genes containing each GO term. Default=2.
     -max_genes_req   Choose maximum number of genes containing each GO term. Default=100000.
     -allow_inferred  Allow inferred parent (GO, not in original file) into final enrichment. Default=0=OFF.
-    -go_algo         topGO algorithm and statistic: classic_fisher (default), weight01_t, elim_ks, weight_ks.
+    -go_algo         topGO algorithm and statistic: classic_fisher (default), weight01_fisher, weight01_t, elim_ks, weight_ks.
+                     NOTE: weight01_t, elim_ks and weight_ks use score-based statistics (t/ks) which require
+                     per-gene numeric scores. The CAFE/chromosome GO input is a gene membership list, so only
+                     the Fisher-based options (classic_fisher, weight01_fisher) produce results with this input.
     -plot_only       Plot Only (BOOLEAN, optional), don't do GO enrichments. Default=0=OFF.
     -open_plot       Open plots once made (BOOLEAN, optional). Default=0=OFF.
 
@@ -149,7 +152,8 @@ my @ALL_made_files;
 my @methods=("holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none");
 
 my ($algo, $stat);
-if    ($go_algo eq "weight01_t") { $algo = "weight01"; $stat = "t"; }
+if    ($go_algo eq "weight01_fisher") { $algo = "weight01"; $stat = "fisher"; }
+elsif ($go_algo eq "weight01_t") { $algo = "weight01"; $stat = "t"; }
 elsif ($go_algo eq "elim_ks")    { $algo = "elim";     $stat = "ks"; }
 elsif ($go_algo eq "weight_ks")  { $algo = "weight";   $stat = "ks"; }
 else                             { $algo = "classic";  $stat = "fisher"; }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -198,7 +198,8 @@
         },
         "go_algo": {
           "type": "string",
-          "description": "topGO algorithm and statistic combination (classic_fisher, weight01_t, elim_ks, weight_ks)",
+          "description": "topGO algorithm and statistic combination (classic_fisher, weight01_fisher, weight01_t, elim_ks, weight_ks). The GO input is a gene membership list, so only the Fisher-based options (classic_fisher, weight01_fisher) produce results; the score-based t/ks options require per-gene scores and yield empty tables with this input.",
+          "enum": ["classic_fisher", "weight01_fisher", "weight01_t", "elim_ks", "weight_ks"],
           "default": "classic_fisher"
         },
         "orthofinder_v2": {


### PR DESCRIPTION
…tfall

The weight01_t/elim_ks/weight_ks options pair the topGO weight01/elim/weight algorithms with score-based statistics (t/ks). The CAFE and chromosome GO input is a gene membership list (0/1 factor), so these statistics produce no results; the R error does not propagate (GO output is optional), so the pipeline reports success with empty *_TopGo_results_ALL.tab tables.

Add weight01_fisher (weight01 algorithm + fisher statistic), which is hierarchy-aware AND compatible with the gene-list input. Add a schema enum so invalid values fail validation, and warn about the t/ks options in the help text and schema description.